### PR TITLE
INF-4610 feature: make crawl timeout and ssh bastion timeout configurable

### DIFF
--- a/itsybitsy/constants.py
+++ b/itsybitsy/constants.py
@@ -7,7 +7,6 @@ import pprint
 # independent constants
 ARGS = None
 CHARLOTTE_DIR = 'charlotte.d'
-CRAWL_TIMEOUT = 30
 OUTPUTS_DIR = 'outputs'
 GRAPHVIZ_RANKDIR_AUTO = 'auto'
 GRAPHVIZ_RANKDIR_TOP_TO_BOTTOM = 'TB'

--- a/itsybitsy/crawl.py
+++ b/itsybitsy/crawl.py
@@ -84,7 +84,7 @@ async def _open_connections(tree: Dict[str, Node], ancestors: List[str]) -> (lis
     # open optional provider connections
     conns = await asyncio.gather(
         *[asyncio.wait_for(
-            _open_connection(node.address, providers.get(node.provider)), constants.CRAWL_TIMEOUT
+            _open_connection(node.address, providers.get(node.provider)), constants.ARGS.timeout
         ) for node_ref, node in tree.items()],
         return_exceptions=True
     )
@@ -130,7 +130,7 @@ async def _lookup_service_names(tree: Dict[str, Node], conns: list) -> (List[str
     service_names = await asyncio.gather(
         *[asyncio.wait_for(
             _lookup_service_name(node.address, providers.get(node.provider), conn),
-            constants.CRAWL_TIMEOUT) for node, conn in zip(tree.values(), conns)],
+            constants.ARGS.timeout) for node, conn in zip(tree.values(), conns)],
         return_exceptions=True
     )
 
@@ -213,14 +213,14 @@ def _compile_crawl_tasks_and_crawl_strategies(address: str, service_name: str, p
         crawl_strategies.append(cs)
         tasks.append(asyncio.wait_for(
             provider.crawl_downstream(address, connection, **cs.provider_args),
-            timeout=constants.CRAWL_TIMEOUT
+            timeout=constants.ARGS.timeout
         ))
 
     # take hints
     for hint in [hint for hint in charlotte_web.hints(service_name)
                  if hint.instance_provider not in constants.ARGS.disable_providers]:
         hint_provider = providers.get(hint.instance_provider)
-        tasks.append(asyncio.wait_for(hint_provider.take_a_hint(hint), timeout=constants.CRAWL_TIMEOUT))
+        tasks.append(asyncio.wait_for(hint_provider.take_a_hint(hint), timeout=constants.ARGS.timeout))
         crawl_strategies.append(
             replace(
                 charlotte.HINT_CRAWL_STRATEGY,

--- a/itsybitsy/itsybitsy.py
+++ b/itsybitsy/itsybitsy.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 import asyncio
 import argparse
@@ -106,10 +106,12 @@ def parse_builtin_args() -> (configargparse.Namespace, list):
                            help='A list of services to highlight in graphviz.')
         sub_p.add_argument('--debug', action='store_true', help='Log debug output to stderr')
 
-    # crawl command args
+    # spider command args
     spider_p.add_argument('-s', '--seeds', required=True, nargs='+', metavar='SEED',
                           help='Seed host(s) to begin crawling viz. an IP address or hostname.  Must be in the format: '
                                '"provider:address".  e.g. "ssh:10.0.0.42" or "k8s:widget-machine-5b5bc8f67f-2qmkp')
+    spider_p.add_argument('-t', '--timeout', type=int, default=60, metavar='TIMEOUT',
+                          help='Timeout when crawling a node')
     spider_p.add_argument('-d', '--max-depth', type=int, default=100, metavar='DEPTH', help='Max tree depth to crawl')
     spider_p.add_argument('-c', '--config-file', is_config_file=True, metavar='FILE', help='Specify a config file path')
     spider_p.add_argument('-X', '--disable-providers', nargs='+', default=[], metavar='PROVIDER',

--- a/itsybitsy/itsybitsy_plugins/provider_ssh.py
+++ b/itsybitsy/itsybitsy_plugins/provider_ssh.py
@@ -33,6 +33,8 @@ class ProviderSSH(ProviderInterface):
 
     @staticmethod
     def register_cli_args(argparser: ProviderArgParser):
+        argparser.add_argument('--bastion-timeout', type=int, default=10, metavar='TIMEOUT',
+                               help='Timeout in seconds to establish SSH connection to bastion (jump server)')
         argparser.add_argument('--concurrency', type=int, default=10, metavar='CONCURRENCY',
                                help='Max number of concurrent SSH connections')
         argparser.add_argument('--config-file', default="~/.ssh/config", metavar='FILE',
@@ -128,7 +130,7 @@ async def _configure(address: str):
 
     try:
         bastion = await asyncio.wait_for(
-            asyncssh.connect(jump_server_address, **ssh_connect_args), timeout=5
+            asyncssh.connect(jump_server_address, **ssh_connect_args), timeout=constants.ARGS.ssh_bastion_timeout
         )
     except asyncio.TimeoutError:
         print(colored(f"Timeout connecting to SSH bastion server: {jump_server_address}.  "

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -20,6 +20,11 @@ def clear_caches():
     crawl.child_cache = {}
 
 
+@pytest.fixture(autouse=True)
+def set_default_timeout(builtin_providers, cli_args_mock):
+    cli_args_mock.timeout = 30
+
+
 @pytest.fixture
 def mock_provider_ref() -> str:
     return 'mock_provider'
@@ -119,10 +124,10 @@ async def test_crawl_case_open_connection_handles_timeout_exception(tree, provid
 
 
 @pytest.mark.asyncio
-async def test_crawl_case_open_connection_handles_timeout(tree, provider_mock, cs_mock, mocker):
+async def test_crawl_case_open_connection_handles_timeout(tree, provider_mock, cs_mock, cli_args_mock, mocker):
     """A natural timeout during ProviderInterface::open_connections is also handled by setting TIMEOUT error"""
     # arrange
-    mocker.patch('itsybitsy.constants.CRAWL_TIMEOUT', .1)
+    cli_args_mock.timeout = .1
 
     async def slow_open_connection(address):
         await asyncio.sleep(1)
@@ -166,10 +171,10 @@ async def test_crawl_case_lookup_name_uses_cache(tree, node_fixture_factory, pro
 
 
 @pytest.mark.asyncio
-async def test_crawl_case_lookup_name_handles_timeout(tree, provider_mock, cs_mock, mocker):
+async def test_crawl_case_lookup_name_handles_timeout(tree, provider_mock, cs_mock, cli_args_mock, mocker):
     """Timeout is handled during lookup_name and results in a sys.exit"""
     # arrange
-    mocker.patch('itsybitsy.constants.CRAWL_TIMEOUT', .1)
+    cli_args_mock.timeout = .1
 
     async def slow_lookup_name(address):
         await asyncio.sleep(1)
@@ -249,10 +254,10 @@ async def test_crawl_case_crawl_downstream_uses_cache(tree, node_fixture_factory
 
 
 @pytest.mark.asyncio
-async def test_crawl_case_crawl_downstream_handles_timeout(tree, provider_mock, cs_mock, mocker):
+async def test_crawl_case_crawl_downstream_handles_timeout(tree, provider_mock, cs_mock, cli_args_mock, mocker):
     """Timeout is respected during crawl_downstream and results in a sys.exit"""
     # arrange
-    mocker.patch('itsybitsy.constants.CRAWL_TIMEOUT', .1)
+    cli_args_mock.timeout = .1
 
     async def slow_crawl_downstream(address, connection):
         await asyncio.sleep(1)
@@ -268,10 +273,10 @@ async def test_crawl_case_crawl_downstream_handles_timeout(tree, provider_mock, 
 
 
 @pytest.mark.asyncio
-async def test_crawl_case_crawl_downstream_handles_exceptions(tree, provider_mock, cs_mock, mocker):
+async def test_crawl_case_crawl_downstream_handles_exceptions(tree, provider_mock, cs_mock, cli_args_mock, mocker):
     """Any exceptions thrown by crawl_downstream are handled by exiting the program"""
     # arrange
-    mocker.patch('itsybitsy.constants.CRAWL_TIMEOUT', .1)
+    cli_args_mock.timeout = .1
     provider_mock.lookup_name.return_value = 'dummy'
     provider_mock.open_connection.side_effect = Exception('BOOM')
 


### PR DESCRIPTION
Kirill was getting bastion server timeouts, increasing from 5->10 seconds seemed to fix for him.
Eugene was getting non bastion timeouts, I am hoping that going from 30->60 seconds fixes this.

Both options are now configurable CLI args