### PR TITLE
BugFix: Disable Providers not working for Arg Parsing

### DIFF
--- a/examples/example-project/requirements.txt
+++ b/examples/example-project/requirements.txt
@@ -1,1 +1,1 @@
-git+ssh://git@github.com/life360-oss/itsybitsy.git#egg=itsybitsy
+git+ssh://git@github.com/etherops/itsybitsy.git#egg=itsybitsy

--- a/itsybitsy/itsybitsy.py
+++ b/itsybitsy/itsybitsy.py
@@ -1,7 +1,7 @@
 # Copyright # Copyright 2020 Life360, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 import asyncio
 import getpass

--- a/itsybitsy/plugins/render_ascii.py
+++ b/itsybitsy/plugins/render_ascii.py
@@ -10,10 +10,19 @@ from collections import namedtuple
 from dataclasses import asdict
 from string import Template
 from termcolor import colored
+from termcolor.termcolor import Color
 from typing import List, Dict
 
 from itsybitsy import constants, logs, renderers
 from itsybitsy.node import Node
+
+
+def colored_force(text: str, color: Color) -> str:
+    """We are only doing this because tests fail if we don't force_color=True
+    due to a tty check in termcolor, and that we haven't figured out the secret
+    sauce to monkeypatching sys.stdin.istty() via fixture in tests where there
+    is no real tty!"""
+    return colored(text, color, force_color=True)
 
 
 class RendererAscii(renderers.RendererInterface):
@@ -170,17 +179,17 @@ def _render_node(node: Node, depth: int, prefix: str, is_last_sibling: bool, out
         branch += f"{bud}--{node.protocol.ref}--{terminus} "
 
     # hint display
-    info = colored('{INFO:FROM_HINT} ', 'cyan') if node.from_hint else ''
+    info = colored_force('{INFO:FROM_HINT} ', "cyan") if node.from_hint else ''
 
     # concise warning display
     concise_warnings = ''
     if not constants.ARGS.render_ascii_verbose and node.warnings:
-        concise_warnings = colored('{WARN:' + '|'.join(node.warnings) + '} ', 'yellow')
+        concise_warnings = colored_force('{WARN:' + '|'.join(node.warnings) + '} ', "yellow")
 
     # concise error display
     concise_errors = ''
     if not constants.ARGS.render_ascii_verbose and node.errors:
-        concise_errors = colored('{ERR:' + '|'.join(node.errors) + '} ', 'red')
+        concise_errors = colored_force('{ERR:' + '|'.join(node.errors) + '} ', "red")
 
     # newline for SEED nodes
     if 0 == depth:
@@ -222,13 +231,13 @@ def _render_node_errs_warns(node: Node, error_prefix: str, out):
     # warnings verbose display
     if node.warnings:
         for warning in node.warnings:
-            print(error_prefix + colored(f"└> WARN: ({warning}): ", "yellow") + warning_messages[warning],
+            print(error_prefix + colored_force(f"└> WARN: ({warning}): ", "yellow") + warning_messages[warning],
                   file=out)
 
     # error verbose display
     if node.errors:
         for error in node.errors:
-            print(error_prefix + colored(f"└> ERROR: ({error}): ", "red") + error_messages[error],
+            print(error_prefix + colored_force(f"└> ERROR: ({error}): ", "red") + error_messages[error],
                   file=out)
 
 
@@ -256,8 +265,8 @@ async def _wait_for_service_names(nodes: Dict[str, Node], depth: int) -> None:
             await asyncio.sleep(5)
     else:
         remaining = _remaining_nodes_for_debugging(nodes)
-        print(colored(f"Infinite wait interrupted waiting for {len(remaining)} services names for: ", 'red'))
-        print(colored(constants.PP.pformat(remaining), 'yellow'))
+        print(colored_force(f"Infinite wait interrupted waiting for {len(remaining)} services names for: ", "red"))
+        print(colored_force(constants.PP.pformat(remaining), "yellow"))
         sys.exit(1)
 
 

--- a/itsybitsy/providers.py
+++ b/itsybitsy/providers.py
@@ -89,7 +89,7 @@ _provider_registry = PluginFamilyRegistry(ProviderInterface)
 
 
 def parse_provider_args(argparser: configargparse.ArgParser):
-    _provider_registry.parse_plugin_args(argparser)
+    _provider_registry.parse_plugin_args(argparser, constants.ARGS.disable_providers)
 
 
 def register_providers():

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ]
     },
     setup_requires=[
-        'wheel~=0.36.2'
+        'wheel>=0.36.2'
     ],
     classifiers=[
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -24,28 +24,28 @@ setup(
         "console_scripts": ['itsybitsy = itsybitsy.itsybitsy:main']
     },
     install_requires=[
-        'asyncssh~=2.2.1',
-        'boto3~=1.16.42',
-        'configargparse~=1.2.3',
-        'coolname~=1.1.0',
-        'faker~=4.1.8',
-        'kubernetes~=11.0.0',
-        'paramiko~=2.7.2',
-        'pyyaml~=5.3.1',
-        'graphviz~=0.13.2',
-        'termcolor~=1.1.0',
+        'asyncssh~=2.14',
+        'boto3~=1.16',
+        'configargparse~=1.2',
+        'coolname~=2.0',
+        'faker>=4.1',
+        'kubernetes~=11.0',
+        'paramiko~=3.4',
+        'pyyaml~=6.0',
+        'graphviz>=0.13',
+        'termcolor~=2.0',
     ],
     extras_require={
         'test': [
-            'prospector~=1.2.0',
-            'pytest~=6.2.1 ',
-            'pytest-asyncio~=0.14.0',
-            'pytest-cov~=2.10.1',
-            'pytest-mock~=3.4.0'
+            'prospector~=1.2',
+            'pytest~=6.2',
+            'pytest-asyncio~=0.14',
+            'pytest-cov~=2.10',
+            'pytest-mock~=3.4'
         ]
     },
     setup_requires=[
-        'wheel>=0.36.2'
+        'wheel>=0.36'
     ],
     classifiers=[
         "Programming Language :: Python :: 3.8",

--- a/tests/plugins/test_render_ascii.py
+++ b/tests/plugins/test_render_ascii.py
@@ -18,6 +18,21 @@ async def _helper_render_tree_with_timeout(tree: Dict[str, Node]) -> None:
     await asyncio.wait_for(render_ascii.render_tree(tree, [], sys.stdout), .1)
 
 
+@pytest.fixture
+def mock_termcolor_colored(mocker):
+    mock = mocker.patch('itsybitsy.plugins.render_ascii.colored', autospec=True)
+    mock.side_effect = lambda text, color, force_color: 'foo'
+    return mock
+
+
+def test_colored_force(mock_termcolor_colored):
+    test_text = "Hello, World!"
+    test_color = "red"
+    result = render_ascii.colored_force(test_text, test_color)
+    # Assert that termcolor_colored was called with the correct arguments
+    mock_termcolor_colored.assert_called_once_with(test_text, test_color, force_color=True)
+
+
 @pytest.mark.asyncio
 async def test_render_tree_case_seed(tree_stubbed, capsys):
     """Test a single seed node is printed correctly - no errors or edge cases"""


### PR DESCRIPTION
Previously, even through you would pass in, for example `--disable-providers=k8s`... itsy would still error out during arg parsing, expecting the `provider_k8s.py` plugin required arguments to be present!

This solution is short term, will write up a long term solution with an appropriate refactor.